### PR TITLE
use core.match syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ But the fun thing is coming, let's say hi to people:
 
 ```clj
 (defun say-hi
-  ([:dennis] "Hi,good morning, dennis.")
-  ([:catty] "Hi, catty, what time is it?")
-  ([:green] "Hi,green, what a good day!")
-  ([other] (str "Say hi to " other)))
+  [:dennis] "Hi,good morning, dennis."
+  [:catty] "Hi, catty, what time is it?"
+  [:green] "Hi,green, what a good day!"
+  [other] (str "Say hi to " other))
 ```
 
 Then calling `say-hi` with different names:
@@ -56,9 +56,9 @@ Let's move on, what about define a recursive function? That's easy too:
 
 ```clj
 (defun count-down
-  ([0] (println "Reach zero!"))
-  ([n] (println n)
-     (recur (dec n))))
+  [0] (println "Reach zero!")
+  [n] (do (println n)
+          (recur (dec n))))
 ```
 
 Invoke it:
@@ -76,22 +76,22 @@ nil
 
 An accumulator from zero to number `n`:
 ```clj
-    (defun accum
-      ([0 ret] ret)
-      ([n ret] (recur (dec n) (+ n ret)))
-      ([n] (recur n 0)))
+(defun accum
+  [0 ret] ret
+  [n ret] (recur (dec n) (+ n ret))
+  [n] (recur n 0))
 
-	 (accum 100)
-	 ;;5050
+  (accum 100)
+  ;;5050
 ```
 
 A fibonacci function:
 
 ```clj
 (defun fib
-    ([0] 0)
-    ([1] 1)
-    ([n] (+ (fib (- n 1)) (fib (- n 2)))))
+  [0] 0
+  [1] 1
+  [n] (+ (fib (- n 1)) (fib (- n 2))))
 ```
 
 Output:
@@ -109,8 +109,8 @@ Added a guard function to parameters:
 
 ```clj
 (defun funny
-  ([(N :guard #(= 42 %))] true)
-  ([_] false))
+  [(N :guard #(= 42 %))] true
+  [_] false)
 
 (funny 42)
 ;;  true
@@ -121,9 +121,9 @@ Another function to detect if longitude  and latitude values are both valid:
 
 ```clj
 (defun valid-geopoint?
-    ([(_ :guard #(and (> % -180) (< % 180)))
-      (_ :guard #(and (> % -90) (< % 90)))] true)
-    ([_ _] false))
+  [(_ :guard #(and (> % -180) (< % 180)))
+   (_ :guard #(and (> % -90) (< % 90)))] true
+  [_ _] false)
 
 (valid-geopoint? 30 30)
 ;; true
@@ -162,10 +162,10 @@ For example, matching literals
 
 ```clj
 (defun test1
-    ([true false] 1)
-    ([true true] 2)
-    ([false true] 3)
-    ([false false] 4))
+  [true false] 1
+  [true true] 2
+  [false true] 3
+  [false false] 4)
 
 (test1 true true)
 ;; 2
@@ -177,9 +177,9 @@ Matching sequence:
 
 ```clj
 (defun test2
-    ([([1] :seq)] :a0)
-    ([([1 2] :seq)] :a1)
-    ([([1 2 nil nil nil] :seq)] :a2))
+  [([1] :seq)] :a0
+  [([1 2] :seq)] :a1
+  [([1 2 nil nil nil] :seq)] :a2)
 
 (test2 [1 2 nil nil nil])
 ;; a2
@@ -189,9 +189,9 @@ Matching vector:
 
 ```clj
 (defun test3
-    ([[_ _ 2]] :a0)
-    ([[1 1 3]] :a1)
-    ([[1 2 3]] :a2))
+  [[_ _ 2]] :a0
+  [[1 1 3]] :a1
+  [[1 2 3]] :a2)
 
 (test3 [1 2 3])
 ;; :a2
@@ -209,13 +209,13 @@ Uses the above function `accum` compared with a normal clojure function:
 (require '[criterium.core :refer [bench])
 
 (defn accum-defn
-    ([n] (accum-defn 0 n))
-    ([ret n] (if (= n 0) ret (recur (+ n ret) (dec n)))))
+  ([n] (accum-defn 0 n))
+  ([ret n] (if (= n 0) ret (recur (+ n ret) (dec n)))))
 
 (defun accum-defun
-  ([0 ret] ret)
-  ([n ret] (recur (dec n) (+ n ret)))
-  ([n] (recur n 0)))
+  [0 ret] ret
+  [n ret] (recur (dec n) (+ n ret))
+  [n] (recur n 0))
 
 (bench (accum-defn 10000))
 ;; Execution time mean : 297.433947 µs

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.match "0.2.1"]])
+                 [org.clojure/core.match "0.2.1"]
+                 [org.clojure/tools.macro "0.1.2"]])

--- a/src/defun.clj
+++ b/src/defun.clj
@@ -1,61 +1,27 @@
-(ns defun
-  "defun: A beautiful macro to define clojure functions.
-    author:  dennis <killme2008@gmail.com>"
-  (:use [clojure.core.match :only (match)]
-        [clojure.walk :only [postwalk]]))
+(ns
+  ^{:author "dennis <killme2008@gmail.com>"
+    :doc "A beautiful macro to define clojure functions"}
+  defun
+  (:require [clojure.core.match :refer [match]]
+            [clojure.tools.macro :refer [name-with-attributes]]
+            [clojure.walk :refer [postwalk]]))
 
 (defmacro defun
-  [name & fdecl]
-  "Define a function just like defn,but using core.match to match parameters.
-   See https://github.com/killme2008/defun for details."
-  ;;processing forms in the same way with defn,
-  ;;the let form below is from clojure.core/defn
-  (let [m (if (string? (first fdecl))
-            {:doc (first fdecl)}
-            {})
-        fdecl (if (string? (first fdecl))
-                (next fdecl)
-                fdecl)
-        m (if (map? (first fdecl))
-            (conj m (first fdecl))
-            m)
-        fdecl (if (map? (first fdecl))
-                (next fdecl)
-                fdecl)
-        fdecl (if (vector? (first fdecl))
-                (list fdecl)
-                fdecl)
-        m (if (map? (last fdecl))
-            (conj m (last fdecl))
-            m)
-        fdecl (if (map? (last fdecl))
-                (butlast fdecl)
-                fdecl)
-        m (conj {:arglists (list 'quote (@#'clojure.core/sigs fdecl))} m)
-        m (let [inline (:inline m)
-                ifn (first inline)
-                iname (second inline)]
-            ;; same as: (if (and (= 'fn ifn) (not (symbol? iname))) ...)
-            (if (if (clojure.lang.Util/equiv 'fn ifn)
-                  (if (instance? clojure.lang.Symbol iname) false true))
-              ;; inserts the same fn name to the inline fn if it does not have one
-              (assoc m :inline (cons ifn (cons (clojure.lang.Symbol/intern (.concat (.getName ^clojure.lang.Symbol name) "__inliner"))
-                                               (next inline))))
-              m))
-        m (conj (if (meta name) (meta name) {}) m)
-        fdecl (postwalk
+ "Define a function just like defn, but using core.match to match parameters.
+  See https://github.com/killme2008/defun for details."
+  [name & pairs]
+  (let [[name pairs] (name-with-attributes name pairs)
+        body (postwalk
                (fn [form]
                  (if (and (list? form) (= 'recur (first form)))
                    (list 'recur (cons 'vector (next form)))
-                   form)) fdecl)]
-    `(defn ~name ~m [ & args#]
-       (match [(vec args#)]
-              ~@(mapcat
-                 (fn [form]
-                   [[(first form)] (cons 'do (next form))])
-                 fdecl)))))
+                   form))
+               (partition 2 pairs))]
+    `(defn ~name [& args#]
+       (match (vec args#)
+              ~@(apply concat body)))))
 
 (defmacro defun-
   "same as defun, yielding non-public def"
   [name & decls]
-    (list* `defun (vary-meta name assoc :private true) decls))
+  (list* `defun (vary-meta name assoc :private true) decls))

--- a/test/defun/core_test.clj
+++ b/test/defun/core_test.clj
@@ -16,10 +16,10 @@
   (testing "say-hi"
     (defun say-hi
       "Say hi to people."
-      ([:dennis] "Hi,good morning, dennis.")
-      ([:catty] "Hi, catty, what time is it?")
-      ([:green] "Hi,green, what a good day!")
-      ([other] (str "Say hi to " other)))
+      [:dennis] "Hi,good morning, dennis."
+      [:catty] "Hi, catty, what time is it?"
+      [:green] "Hi,green, what a good day!"
+      [other] (str "Say hi to " other))
     (is (= "Hi,good morning, dennis." (say-hi :dennis)))
     (is (= "Hi, catty, what time is it?" (say-hi :catty)))
     (is (= "Hi,green, what a good day!" (say-hi :green)))
@@ -28,61 +28,61 @@
 (deftest test-recursive-function
   (testing "accum"
     (defun accum
-      ([0 ret] ret)
-      ([n ret] (recur (dec n) (+ n ret)))
-      ([n] (recur n 0)))
+      [0 ret] ret
+      [n ret] (recur (dec n) (+ n ret))
+      [n] (recur n 0))
     (is (= 6 (accum 3)))
     (is (= 5050 (accum 100))))
   (testing "fib"
     (defun fib
-      ([0] 0)
-      ([1] 1)
-      ([n] (+ (fib (- n 1)) (fib (- n 2)))))
+      [0] 0
+      [1] 1
+      [n] (+ (fib (- n 1)) (fib (- n 2))))
     (is (= 55 (fib 10)))))
 
 (deftest test-guards
   (testing "funny"
     (defun funny
-      ([(N :guard #(= 42 %))] true)
-      ([_] false))
+      [(N :guard #(= 42 %))] true
+      [_] false)
     (is (funny 42))
     (is (not (funny 43))))
   (testing "valid-geopoint?"
     (defun valid-geopoint?
-      ([(_ :guard #(and (> % -180) (< % 180)))
-        (_ :guard #(and (> % -90) (< % 90)))] true)
-      ([_ _] false))
+      [(_ :guard #(and (> % -180) (< % 180)))
+       (_ :guard #(and (> % -90) (< % 90)))] true
+      [_ _] false)
     (is (valid-geopoint? 30 30))
     (is (not (valid-geopoint? -181 30)))))
 
 (deftest test-match-literals
   (testing "test1"
     (defun test1
-    ([true false] 1)
-    ([true true] 2)
-    ([false true] 3)
-    ([false false] 4))
+      [true false] 1
+      [true true] 2
+      [false true] 3
+      [false false] 4)
     (is (= 2 (test1 true true)))
     (is (= 4 (test1 false false)))))
 
 (deftest test-match-vector
   (testing "test3"
     (defun test3
-    ([[_ _ 2]] :a0)
-    ([[1 1 3]] :a1)
-    ([[1 2 3]] :a2))
+      [[_ _ 2]] :a0
+      [[1 1 3]] :a1
+      [[1 2 3]] :a2)
     (is (= :a2 (test3 [1 2 3])))
     (is (= :a0 (test3 [3 3 2])))
     (is (= :a1 (test3 [1 1 3]))))
   (testing "test2"
     (defun test2
-    ([([1] :seq)] :a0)
-    ([([1 2] :seq)] :a1)
-    ([([1 2 nil nil nil] :seq)] :a2))
+      [([1] :seq)] :a0
+      [([1 2] :seq)] :a1
+      [([1 2 nil nil nil] :seq)] :a2)
     (is (= :a2 (test2 [1 2 nil nil nil])))))
 
 (deftest test-private-macro
   (testing "test1"
     (defun- test1
-      ([_]))
+      [_])
     (is (:private (meta #'test1)))))


### PR DESCRIPTION
I decided to try and use the same syntax from `core.match`. The downside is when you want side-effects. In this case, you do not have the benefit of the wrapping list for each match body and require a `do` form.

``` clojure
;; Old Way
(defun foo
  ([x] (println "Hello!") (* 2 x))
  ([2] :bar))

;; New Way
(defun foo
  [x] (do (println "Hello!") (* 2 x))
  [2] :bar)
```

When you use guards or some of the more _complex_ syntax of `core.match`, I think following their exact syntax is a bit easier.

``` clojure
(defun funny
  [(N :guard #(= 42 %))] true
  [_] false)
```

Let me know what you think about this. Thanks!
