### PR TITLE
Optimize args matching for non-variadic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,23 +260,23 @@ Uses the above function `accum` compared with a normal clojure function:
   ([n] (recur n 0)))
 
 (bench (accum-defn 10000))
-;;Evaluation count : 210480 in 60 samples of 3508 calls.
-;;             Execution time mean : 281.095682 µs
-;;    Execution time std-deviation : 2.526939 µs
-;;   Execution time lower quantile : 277.691624 µs ( 2.5%)
-;;   Execution time upper quantile : 286.618249 µs (97.5%)
-;;                   Overhead used : 1.648269 ns
+;;Evaluation count : 106740 in 60 samples of 1779 calls.
+;;             Execution time mean : 578.777537 µs
+;;    Execution time std-deviation : 23.354350 µs
+;;   Execution time lower quantile : 552.627735 µs ( 2.5%)
+;;   Execution time upper quantile : 637.001868 µs (97.5%)
+;;                   Overhead used : 17.111650 ns
 
 (bench (accum-defun 10000))
-;;Evaluation count : 26820 in 60 samples of 447 calls.
-;;             Execution time mean : 2.253477 ms
-;;    Execution time std-deviation : 13.082041 µs
-;;   Execution time lower quantile : 2.235795 ms ( 2.5%)
-;;   Execution time upper quantile : 2.281963 ms (97.5%)
-;;                   Overhead used : 1.648269 ns
+;;Evaluation count : 54660 in 60 samples of 911 calls.
+;;             Execution time mean : 1.115643 ms
+;;    Execution time std-deviation : 32.916487 µs
+;;   Execution time lower quantile : 1.078117 ms ( 2.5%)
+;;   Execution time upper quantile : 1.180711 ms (97.5%)
+;;                   Overhead used : 17.111650 ns
 ```
 
-accum-defn is much faster than accum-defun. Pattern matching does have a tradeoff.
+accum-defn is faster than accum-defun. Pattern matching does have a tradeoff.
 
 ## Contributors
 

--- a/src/defun/core.cljc
+++ b/src/defun/core.cljc
@@ -24,14 +24,17 @@
      `(if-cljs (cljs.core.match/match ~@args)
                (clojure.core.match/match ~@args))))
 
+(def placeholder (Object.))
+
 #?(:clj
-   (defmacro fun
+   (defmacro fun*
      "Defines a function just like clojure.core/fn with parameter pattern matching
      See https://github.com/killme2008/defun for details."
      [& sigs]
      {:forms '[(fun name? [params* ] exprs*) (fun name? ([params* ] exprs*)+)]}
      (let [name (when (symbol? (first sigs)) (first sigs))
            sigs (if name (next sigs) sigs)
+           name (or name (gensym "fn__"))
            sigs (if (vector? (first sigs))
                   (list sigs)
                   (if (seq? (first sigs))
@@ -51,21 +54,94 @@
                                    (first sigs)
                                    " should be a vector")
                               "Parameter declaration missing")))))
-           sigs (postwalk
-                 (fn [form]
-                   (if (and (list? form) (= 'recur (first form)))
-                     (list 'recur (cons 'vector (next form)))
-                     form))
-                 sigs)
-           sigs `([& args#]
-                  (match (vec args#)
-                         ~@(mapcat
+           sigs (sort-by #(count (first %)) sigs)
+           args (map first sigs)
+           arities (set (map count args))
+           max-arity (apply max arities)
+           other-arities (disj arities max-arity)
+           placeholder-sym (gensym "placeholder")
+           placeholder-syms (cons placeholder-sym (repeat '_))
+           args
+           (map #(into % (take (- max-arity (count %)) placeholder-syms)) args)
+           bodies (map #(cons 'do %) (map rest sigs))
+           bodies (postwalk
+                   (fn [form]
+                     (if (and (list? form) (= 'recur (first form)))
+                       (let [recur-args (next form)
+                             recur-args-n (count recur-args)
+                             to-add-n (- max-arity recur-args-n)
+                             tail (take to-add-n (repeat `placeholder))]
+                         (cons 'recur (concat recur-args tail)))
+                       form))
+                    bodies)
+           statements (interleave args bodies)
+           args* (vec (take (count (first args)) (repeatedly gensym)))
+           main-sig (list
+                     args*
+                     (list
+                      `let [placeholder-sym `placeholder]
+                      (list* `match args* statements)))
+           other-sigs (map (fn [a]
+                             (let [args (subvec args* 0 a)
+                                   to-add-n (- max-arity a)
+                                   tail (take to-add-n (repeat `placeholder))]
+                               (list args (cons name (concat args tail)))))
+                       other-arities)
+           all-sigs (concat other-sigs [main-sig])]
+       (list* `fn name all-sigs))))
+
+(defn variadic? [sigs]
+  (->> sigs
+    (map first)
+    (map (partial some #{'&}))
+    (filter some?)
+    (seq)
+    (boolean)))
+
+#?(:clj
+   (defmacro fun
+     "Defines a function just like clojure.core/fn with parameter pattern matching
+     See https://github.com/killme2008/defun for details."
+     [& sigs]
+     {:forms '[(fun name? [params* ] exprs*) (fun name? ([params* ] exprs*)+)]}
+     (let [name (when (symbol? (first sigs)) (first sigs))
+           sigs (if name (next sigs) sigs)
+           sigs (if (vector? (first sigs))
+                  (list sigs)
+                  (if (seq? (first sigs))
+                    (let [sig-args (map first sigs)]
+                      (if-some [[form] (some #(if-not (vector? %) [%]) sig-args)]
+                        (throw (IllegalArgumentException.
+                                 (if (some? form)
+                                   (str "Parameter declaration "
+                                     form
+                                     " should be a vector")
+                                   (str "Parameter declaration missing"))))
+                        sigs))
+                    ;; Assume single arity syntax
+                    (throw (IllegalArgumentException.
+                             (if (seq sigs)
+                               (str "Parameter declaration "
+                                 (first sigs)
+                                 " should be a vector")
+                               "Parameter declaration missing")))))]
+       (if (variadic? sigs)
+         (let [sigs (postwalk
+                      (fn [form]
+                        (if (and (list? form) (= 'recur (first form)))
+                          (list 'recur (cons 'vector (next form)))
+                          form))
+                      sigs)
+               sigs `([& args#]
+                      (match (vec args#)
+                        ~@(mapcat
                             (fn [[m & more]]
                               [m (cons 'do more)])
                             sigs)))]
-       (list* 'fn (if name
-                    (cons name sigs)
-                    sigs)))))
+           (list* 'fn (if name
+                        (cons name sigs)
+                        sigs)))
+         `(fun* ~@sigs)))))
 
 #?(:clj
    (defmacro letfun


### PR DESCRIPTION
The following version of `defun` is almost 3x faster on non-variadic functions on my machine. The performance improvement is achieved by avoiding wrapping the function arguments into a vector on each call.

It works like this (considering the example from the README). The `defun` declaration

```clojure
(defun accum-defun
  ([0 ret] ret)
  ([n ret] (recur (dec n) (+ n ret)))
  ([n] (recur n 0)))
```

produces the following:

```clojure
(def accum-defun
 (fn fn__17870
   ([G__17872] (fn__17870 G__17872 defun.core/placeholder))
   ([G__17872 G__17873]
    (let [placeholder17871 defun.core/placeholder]
      (match [G__17872 G__17873]
        [n placeholder17871] (do (recur n 0))
        [0 ret] (do ret)
        [n ret] (do (recur (dec n) (+ n ret))))))))
```

The idea is that all the matching always happens in the body with the greatest arity. All the arguments are matched using the vector syntax of `match`. The macro uses a placeholder object to distinguish between signatures of different arities.

For the variadics nothing has changed - the macro generates the same code as before.

I would appreciate if you could check the benchmarks on your machine/java version.