### PR TITLE
Updated deps to latest versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.match "0.3.0-alpha4"]
-                 [org.clojure/tools.macro "0.1.2"]])
+                 [org.clojure/core.match "1.0.1"]
+                 [org.clojure/tools.macro "0.1.5"]])


### PR DESCRIPTION
... to fix many warnings like:
`WARNING: update-vals already refers to: #'clojure.core/update-vals in namespace: clojure.tools.analyzer.utils, being replaced by: #'clojure.tools.analyzer.utils/update-vals`